### PR TITLE
non-flat

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${var.node_pool_metadata}"
+    metadata        = "${element(lookup(var.node_pool[count.index], "metadata", ""), 0)}
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(lookup(var.node_pool[count.index], "node_pool_metadata", 10), 0)}"
+    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}")}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${data.template_file["node_pool_metadata"]}"
+    metadata        = "${lookup(data.template_file.node_pool_metadata.*.rendered, "node_pool_metadata")}"
 #    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(${var.node_pool_metadata}, 0)}"
+    metadata        = "${element(var.node_pool_metadata, 0)}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(lookup(var.node_pool[count.index], "metadata", []), 0)}"
+    metadata        = "${count.index == 0 ? var.node_pool_blue_metadata : var.node_pool_green_metadata}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -13,10 +13,7 @@ data "google_container_engine_versions" "region" {
 }
 
 locals {
-  metadata_map {
-    0 = "${var.node_pool_blue_metadata}"
-    1 = "${var.node_pool_green_metadata}"
-  }
+  metadata_list = ["${var.node_pool_blue_metadata}",  "${var.node_pool_green_metadata}"]
 }
 
 # Manages a Node Pool resource within GKE
@@ -41,7 +38,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${local.metadata_map[count.index]}"
+    metadata        = "${local.metadata_list[count.index]}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,11 @@ data "google_container_engine_versions" "region" {
   region = "${var.general["region"]}"
 }
 
+data "template_file" "node_pool_metadata" {
+  template = "${lookup(var.node_pool[count.index])}"
+  count = "${length(var.node_pool)}"
+}
+
 # Manages a Node Pool resource within GKE
 # https://www.terraform.io/docs/providers/google/r/container_node_pool.html
 resource "google_container_node_pool" "new_container_cluster_node_pool" {
@@ -34,7 +39,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${lookup(var.node_pool[count.index]["node_pool_metadata"])}"
+    metadata        = "${data.template_file["node_pool_metadata"]}"
 #    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${var.node_pool[count.index]["node_pool_metadata"]}"
+    metadata        = "${element(var.node_pool, count.index)["node_pool_metadata"]}"
 #    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,8 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
+    metadata        = "${lookup(var.node_pool[count.index], "node_pool_metadata")}"
+#    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(lookup(var.node_pool[count.index], "metadata", ""), 0)}
+    metadata        = "${element(lookup(var.node_pool[count.index], "metadata", ""), 0)}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${var.node_pool_metadata}"
+    metadata        = "${element(${var.node_pool_metadata}, 0)}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}")}"
+    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${lookup(var.node_pool[count.index], "node_pool_metadata")}"
+    metadata        = "${var.node_pool[count.index]["node_pool_metadata"]}"
 #    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(lookup(var.node_pool[count.index], "node_pool_metadata", ""), 0)}"
+    metadata        = "${element(lookup(var.node_pool[count.index], "node_pool_metadata", 10), 0)}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,11 @@ data "google_container_engine_versions" "region" {
   region = "${var.general["region"]}"
 }
 
-data "template_file" "node_pool_metadata" {
-  template = "${lookup(var.node_pool[count.index])}"
-  count = "${length(var.node_pool)}"
+locals {
+  metadata_map {
+    0 = "${var.node_pool_blue_metadata}"
+    1 = "${var.node_pool_green_metadata}"
+  }
 }
 
 # Manages a Node Pool resource within GKE
@@ -39,8 +41,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${lookup(data.template_file.node_pool_metadata.*.rendered, "node_pool_metadata")}"
-#    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
+    metadata        = "${local.metadata_map[count.index]}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${lookup(var.node_pool[count.index], "metadata", "")}"
+    metadata        = "${var.node_pool[count.index]["metadata"]}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${var.node_pool_metadata}
+    metadata        = "${var.node_pool_metadata}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${var.node_pool[count.index]["metadata"]}"
+    metadata        = "${var.node_pool_metadata}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${count.index == 0 ? var.node_pool_blue_metadata : var.node_pool_green_metadata}"
+    metadata        = "${var.node_pool_metadata}
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(lookup(var.node_pool[count.index], "metadata", ""), 0)}"
+    metadata        = "${element(lookup(var.node_pool[count.index], "metadata", []), 0)}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(var.node_pool, count.index)["node_pool_metadata"]}"
+    metadata        = "${lookup(var.node_pool[count.index]["node_pool_metadata"])}"
 #    metadata        =  "${element(split(",", lookup(var.node_pool[count.index], "node_pool_metadata", "")), 0)}"
   }
 

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${element(var.node_pool_metadata, 0)}"
+    metadata        = "${lookup(var.node_pool[count.index], "node_pool_metadata", "")}"
   }
 
   #autoscaling {

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "google_container_node_pool" "new_container_cluster_node_pool" {
     service_account = "${lookup(var.node_pool[count.index], "service_account", "default")}"
     labels          = "${var.labels}"
     tags            = "${var.tags}"
-    metadata        = "${lookup(var.node_pool[count.index], "node_pool_metadata", "")}"
+    metadata        = "${element(lookup(var.node_pool[count.index], "node_pool_metadata", ""), 0)}"
   }
 
   #autoscaling {

--- a/variables.tf
+++ b/variables.tf
@@ -148,3 +148,6 @@ variable "env" {
 variable "cluster_key" {
   type = "string"
 }
+
+variable "node_pool_blue_metadata" {}
+variable "node_pool_green_metadata" {}

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,7 @@ variable "labels" {
   default     = {}
 }
 
+variable "node_pool_metadata" { default = {} }
 # https://www.terraform.io/docs/providers/google/r/container_cluster.html#metadata
 variable "metadata" {
   description = "The metadata key/value pairs assigned to instances in the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -84,8 +84,7 @@ variable "labels" {
   default     = {}
 }
 
-variable "node_pool_blue_metadata" { default = {} }
-variable "node_pool_green_metadata" { default = {} }
+variable "node_pool_metadata" { default = {} }
 # https://www.terraform.io/docs/providers/google/r/container_cluster.html#metadata
 variable "metadata" {
   description = "The metadata key/value pairs assigned to instances in the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -84,7 +84,6 @@ variable "labels" {
   default     = {}
 }
 
-variable "node_pool_metadata" { default = {} }
 # https://www.terraform.io/docs/providers/google/r/container_cluster.html#metadata
 variable "metadata" {
   description = "The metadata key/value pairs assigned to instances in the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -149,5 +149,5 @@ variable "cluster_key" {
   type = "string"
 }
 
-variable "node_pool_blue_metadata" {}
-variable "node_pool_green_metadata" {}
+variable "node_pool_blue_metadata" { type = "map" }
+variable "node_pool_green_metadata" { type = "map" }

--- a/variables.tf
+++ b/variables.tf
@@ -84,7 +84,8 @@ variable "labels" {
   default     = {}
 }
 
-variable "node_pool_metadata" { default = {} }
+variable "node_pool_blue_metadata" { default = {} }
+variable "node_pool_green_metadata" { default = {} }
 # https://www.terraform.io/docs/providers/google/r/container_cluster.html#metadata
 variable "metadata" {
   description = "The metadata key/value pairs assigned to instances in the cluster"


### PR DESCRIPTION
Makes a separate list for the node pool metadata because passing a nested map inside a list to a module is very tricky otherwise 